### PR TITLE
Work around rvm ruby-head build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,5 @@ rvm:
   - ruby-head
 before_install:
   - gem update --system
-  - gem install bundler --no-document
-matrix:
-  allow_failures:
-    - rvm: ruby-head
+  - gem install bundler -v "~> 2.0" --conservative --no-document
+  - gem install executable-hooks --conservative --no-document


### PR DESCRIPTION
Currently rvm fails to install ruby-head completely on Travis with errors like:

    there was an error installing gem gem-wrappers

This leaves the ruby environment in an inconsistent state where binstubs fail to execute with errors like:

    /usr/bin/env: ruby_executable_hooks: No such file or directory

Manually installing the executable-hooks gem fixes these errors.