### PR TITLE
Fix travis build failure with ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ rvm:
 - 2.6.5
 - ruby-head
 before_install:
-- gem update --system
 - gem install bundler -v 2.0.2 --conservative --no-document
 - gem install executable-hooks --conservative --no-document


### PR DESCRIPTION
The rubygems upgrade seems to lead to a prompt like this that waits for user input, eventually timing out and failing the build:

```
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-head/bin/bundle
Overwrite the executable? [yN]
```

Fix by removing the rubygems upgrade.

Describe what you changed and why you changed it, and then review the checklist below.

---

- [ ] All tests and RuboCop checks pass (`bundle exec rake`)
- [ ] Test(s) included
