### PR TITLE
Take advantage of Semaphore bundler cache

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,23 +4,30 @@ agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu2004
+global_job_config:
+  env_vars:
+    - name: BUNDLE_PATH
+      value: "./vendor/bundle"
+  prologue:
+    commands:
+      - checkout
+      - export SEM_RUBY=${SEM_RUBY:-3.2.0}
+      - sem-version ruby $SEM_RUBY
+      - cache restore "gems-${SEM_RUBY}-${SEMAPHORE_GIT_BRANCH}-,gems-${SEM_RUBY}-main-"
+      - bundle check || bundle install
+      - cache store "gems-${SEM_RUBY}-${SEMAPHORE_GIT_BRANCH}-$(checksum Gemfile.lock)" vendor/bundle
 blocks:
-  - name: Ruby
+  - name: Rubocop
+    dependencies: []
     task:
-      env_vars:
-        - name: BUNDLE_PATH
-          value: vendor/bundle
-      prologue:
-        commands:
-          - checkout
-          - sem-version ruby ${SEM_RUBY:-3.2.0}
-          - cache restore
-          - bundle check || bundle install
-          - cache store
       jobs:
         - name: Rubocop
           commands:
             - bundle exec rubocop
+  - name: Test
+    dependencies: []
+    task:
+      jobs:
         - name: Test
           matrix:
             - env_var: SEM_RUBY


### PR DESCRIPTION
* Take advantage of Semaphore bundler cache
* Split Rubocop and Test into separate blocks
* Allow blocks to run in parallel
