### PR TITLE
Replace minitest-reporters with minitest-rg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem "amazing_print", "~> 1.0"
 gem "minitest", "~> 5.0"
-gem "minitest-reporters", "~>1.1"
+gem "minitest-rg", "~> 5.3"
 gem "rake", "~> 13.0", "!= 13.0.2"
 gem "rexml", "~> 3.2"
 gem "rubocop", "1.58.0"

--- a/test/support/reporters.rb
+++ b/test/support/reporters.rb
@@ -1,7 +1,0 @@
-require "minitest/reporters"
-
-if ENV["CI"]
-  Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)
-else
-  Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new)
-end

--- a/test/support/rg.rb
+++ b/test/support/rg.rb
@@ -1,0 +1,2 @@
+# Enable color test output
+require "minitest/rg"


### PR DESCRIPTION
Remove `minitest-reporters` in favor of `minitest-rg`, which is simpler, is officially maintained by the minitest GitHub organization, and doesn't patch minitest internals in ways that can break other plugins