### PR TITLE
Drop support for Ruby 3.0 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.1", "3.2", "3.3", "head"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or install it yourself as:
 
     $ gem install jess
 
-*Note that Jess requires Ruby 3.0 or newer.*
+*Note that Jess requires Ruby 3.1 or newer.*
 
 ## Usage
 

--- a/jess.gemspec
+++ b/jess.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Lightweight, unofficial client for the JAMF Software Server (JSS) API"
   spec.homepage = "https://github.com/mattbrictson/jess"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.metadata = {
     "homepage_uri" => spec.homepage,

--- a/lib/jess.rb
+++ b/lib/jess.rb
@@ -26,7 +26,7 @@ module Jess
   # using the desired options, then pass it to Jess::Connection.new.
   #
   def self.connect(url, username:, password:)
-    client = HttpClient.new(url, username: username, password: password)
+    client = HttpClient.new(url, username:, password:)
     Connection.new(client)
   end
 end

--- a/test/jess/http_client_test.rb
+++ b/test/jess/http_client_test.rb
@@ -34,7 +34,7 @@ class Jess::HttpClientTest < Minitest::Test
 
   def test_logs_successful_request
     logger = FakeLogger.new
-    client = new_client(logger: logger)
+    client = new_client(logger:)
     stub_http_get("https://host/JSSResource/test").to_return(
       body: '{ "sample": "value" }',
       headers: { "Content-Type" => "application/json" }
@@ -52,7 +52,7 @@ class Jess::HttpClientTest < Minitest::Test
 
   def test_logs_empty_request
     logger = FakeLogger.new
-    client = new_client(logger: logger)
+    client = new_client(logger:)
     stub_http_get("https://host/JSSResource/test")
     client.get("test")
 
@@ -67,7 +67,7 @@ class Jess::HttpClientTest < Minitest::Test
 
   def test_logs_error
     logger = FakeLogger.new
-    client = new_client(logger: logger)
+    client = new_client(logger:)
     stub_http_get("https://host/JSSResource/test")
       .to_return(status: [404, "Not found"])
 
@@ -88,7 +88,7 @@ class Jess::HttpClientTest < Minitest::Test
 
   def test_logs_error_with_status_if_no_message_present
     logger = FakeLogger.new
-    client = new_client(logger: logger)
+    client = new_client(logger:)
     stub_http_get("https://host/JSSResource/test")
       .to_return(status: [503, ""])
 
@@ -109,7 +109,7 @@ class Jess::HttpClientTest < Minitest::Test
 
   def test_includes_response_body_in_exception
     logger = FakeLogger.new
-    client = new_client(logger: logger)
+    client = new_client(logger:)
     stub_http_get("https://host/JSSResource/test")
       .to_return(body: "Oh no!", status: [500, "Internal Server Error"])
 
@@ -225,7 +225,7 @@ class Jess::HttpClientTest < Minitest::Test
       url,
       username: "demo_user",
       password: "demo_password",
-      logger: logger
+      logger:
     )
   end
 

--- a/test/jess_test.rb
+++ b/test/jess_test.rb
@@ -10,7 +10,7 @@ class JessTest < Minitest::Test
     username = "hello"
     password = "hush"
 
-    conn = Jess.connect(url, username: username, password: password)
+    conn = Jess.connect(url, username:, password:)
 
     assert_instance_of(Jess::Connection, conn)
 


### PR DESCRIPTION
- Adopt Ruby 3.1+ implicit hash syntax
