### PR TITLE
Add logger dependency to address Ruby 3.4 warning

### DIFF
--- a/jess.gemspec
+++ b/jess.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_dependency "logger", ">= 1.4.2"
 end


### PR DESCRIPTION
Add the `logger` gem dependency to fix the following warning:

> lib/jess/http_client.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.