### PR TITLE
Fix frozen string warning on Ruby 3.4

### DIFF
--- a/lib/jess/http_client/logging_decorator.rb
+++ b/lib/jess/http_client/logging_decorator.rb
@@ -37,7 +37,7 @@ module Jess
 
       def response_desc(response)
         content_type = response.content_type
-        desc = ""
+        desc = +""
         desc << if response.body && response.body.length
                   "#{response.body.length} bytes"
                 else


### PR DESCRIPTION
Fix the following warning on Ruby 3.4:

> lib/jess/http_client/logging_decorator.rb:41: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
